### PR TITLE
markdown -> html fix

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -5,7 +5,9 @@ title: Projects
 ---
 
 # Projects
+
 ## CommentBlock
+
 [CommentBlock](https://github.com/freenode-feminism/CommentBlock/) is an AdBlock Plus filter subscription that hides the user comment section on various popular websites.
 Most websites lack decent or any moderation of their commenting section, allowing an enviroment full of 
 trolls, ignorance, and bigotry to become an unsettling echo chamber.


### PR DESCRIPTION
The `CommentBlock` heading isn't being rendered into HTML, so I added a newline before and after it, in hopes that it will get rendered in the next build.

See: http://freenode-feminism.github.io/projects/
Screenshot: http://i.imgur.com/27YzfRF.png