### PR TITLE
Replace kiwiirc link with irccloud recommendation

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,9 @@ A guide on obtaining a cloak can be found [here](/cloak/).
 
 ## Via Webchat
 
-[![Visit our IRC channel](https://kiwiirc.com/buttons/chat.freenode.net/%23feminism.png)](https://kiwiirc.com/client/chat.freenode.net:+6697/##feminism)
+Some common web gateways are unable to access ##feminism due to repeated misuse. If you're unable to install a client, [IRCCloud](https://irccloud.com) offers "trial" accounts for no cost. You will need to make sure you select the freenode network.
+
+IRCCloud accounts get a gateway cloak which does not display your IP address or host.
 
 ***
 


### PR DESCRIPTION
Button was causing confusion as kiwiirc is now banforwarded to ##feminism-gateways due to misuse.